### PR TITLE
RxJava isn't needed, it's enough to list all future and sequence them

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -78,7 +78,6 @@ dependencies {
     compile 'org.hibernate:hibernate-validator'
     compile "org.aspectj:aspectjrt"
     compile "com.ofg:micro-infra-spring-boot-starter:$microInfraSpringVersion"
-    compile 'io.reactivex:rxjava:1.0.12'
     compile 'org.projectlombok:lombok:1.16.4'
 
     runtime 'cglib:cglib-nodep:3.1'


### PR DESCRIPTION
This implementation transforms ingredient names to `List<ListenableFuture<Ingredient>>` and
later sequences them to `ListenableFuture<List<Ingredient>>`

Ideally we should return `ListenableFuture<Ingredients>` and later simply return future from controller (!)
which is similar to returning `DeferredResult`. Unfortunately Spring only supports copy-pasted
`org.springframework.util.concurrent.ListenableFuture` and not `com.google.common.util.concurrent.ListenableFuture`
returned from async-retry library.
These two are incompatible and Spring MVC can't properly dispatch it
 (see: `org.springframework.web.servlet.mvc.method.annotation.ListenableFutureReturnValueHandler`)

BTW Spring MVC 4.2 will allow `CompletableFuture` to be returned from controllers.
